### PR TITLE
Fix duplicate method and bracketing

### DIFF
--- a/ControlValue.sc
+++ b/ControlValue.sc
@@ -257,11 +257,6 @@ BusControlValue : NumericControlValue {
 	asMap { ^this.bus.asMap }
 	asBus { ^this.bus }
 }
-		}
-	}
-
-	asMap { ^this.bus.asMap }
-}
 
 OnOffControlValue : AbstractControlValue {
 	var value, onSig, offSig;


### PR DESCRIPTION
This error came up on the SC list. Just a small bracketing fix. Also removed the duplicate `asMap` method.