### PR TITLE
allow access to the input variable in the methodString

### DIFF
--- a/Slots.sc
+++ b/Slots.sc
@@ -35,7 +35,7 @@ MethodSlot {
 			Exception("Object of type % doesn't respond to %.".format(reciever.class, methodName)).throw;
 		};
 
-		^"{ |reciever, object, changed, args| var value = args[0]; reciever.% }".format(methodString).interpret;
+		^"{ |reciever, object, changed, args| var value = args[0]; var input = args[1]; reciever.% }".format(methodString).interpret;
 	}
 
 	update {


### PR DESCRIPTION
This PR ensures the "input" is available to the methodString. It works with the NumericControlValue class and I don't think this change would break anything but users would need to be aware that input will be Nil unless the .changed(\what, value, valueUnmapped) pattern is followed.

I think the reason for this PR is best shown through an example:
```
(

~controls = [
    ~amp     = NumericControlValue(spec:ControlSpec(0, 1, default: 0 )),
    ~freq     = NumericControlValue(spec:ControlSpec(10, 1000, default: 100 )),
    ~delay     = NumericControlValue(spec:ControlSpec(0.05, 2, default: 1 )),
    ~decay    = NumericControlValue(spec:ControlSpec(0.05, 2, \exp, default: 2 )),
    ~filterFreq = NumericControlValue(spec:ControlSpec(30, 5000, \exp, default: 1000 )),
];

~view = View(bounds:600@200).layout_(GridLayout.rows(
    ~sliders = 5.collect { Slider() },
    ~numbers = 5.collect { NumberBox() }
)).front;

~view.onClose = { ~synth.free; ~connections.disconnect };

~connections = ConnectionList.make({
    ~controls.connectEach(\value, ~sliders, _.methodSlot("value_(input)"));
    // The alternative line below fails to successfully supply the input value
    // when calling onSignalDependantAdded
    // due to ControlValue.sc line 67 having \value hardcoded.
    // ~controls.connectEach(\input, ~sliders, _.valueSlot);
	
    ~controls.connectEach(\value, ~numbers, _.valueSlot);
    ~sliders.connectEach(\value, ~controls, _.inputSlot);
    ~numbers.connectEach(\value, ~controls, _.valueSlot);
});
)
```
Thank you for this library Scott, it's very useful and I spent a while trying to figure out how I might build instruments using an MVC approach before finding this.