### PR TITLE
Fix error when instantiating IndexedControlValue

### DIFF
--- a/ControlValue.sc
+++ b/ControlValue.sc
@@ -85,12 +85,14 @@ AbstractControlValue {
 	signal {
 		|keyOrFunc|
 		if (keyOrFunc == \input) {
-			^inputTransform ?? {
+			^if (inputTransform.isNil or: { inputTransform.dependants.isNil }) {
 				inputTransform = super.signal(\value).transform({
 					|obj, what, value, unmappedValue|
 					[obj, what, unmappedValue]
 				})
-			}
+			} {
+				inputTransform
+			};
 		} {
 			^super.signal(keyOrFunc)
 		}

--- a/ControlValue.sc
+++ b/ControlValue.sc
@@ -172,7 +172,7 @@ NumericControlValue : AbstractControlValue {
 }
 
 IndexedControlValue : AbstractControlValue {
-	*defaultSpec { ^ItemsSpec([]) }
+	*defaultSpec { ^ItemSpec([]) }
 
 	next {
 		var index;

--- a/ControlValue.sc
+++ b/ControlValue.sc
@@ -261,49 +261,26 @@ BusControlValue : NumericControlValue {
 	asBus { ^this.bus }
 }
 
-OnOffControlValue : AbstractControlValue {
+OnOffControlValue : IndexedControlValue {
 	var value, onSig, offSig;
 
 	*defaultSpec { ^ItemSpec([\off, \on]) }
 
 	on {
-		this.value = \on;
+		this.input = 1;
 	}
 
 	off {
-		this.value = \off;
+		this.input = 0;
 	}
 
 	toggle {
-		this.value = (value == \on).if(\off, \on);
-	}
-
-	value_{
-		|inVal|
-		if ((inVal == \on) || (inVal == \off)) {
-			if (inVal != value) {
-				value = inVal;
-				this.changed(\value, value);
-				this.changed(inVal);
-			}
-		} {
-			Error("Value must be \off or \on").throw
-		}
-	}
-
-	input_{
-		|inputVal|
-		this.value = (inputVal > 0.5).if(\on, \off);
+		this.input = 1 - this.input;
 	}
 
 	input {
-		^switch (value,
-			{ \off }, { 0 },
-			{ \on }, { 1 }
-		)
+		^spec.items.indexOf(value)
 	}
-
-	constrain {}
 }
 
 MIDIControlValue : NumericControlValue {

--- a/ItemSpec.sc
+++ b/ItemSpec.sc
@@ -33,5 +33,13 @@ ItemSpec : ControlSpec {
 	copy {
 		^this.class.newFrom(this)
 	}
+
+	constrain { arg value;
+		if (items.includes(value).not) {
+			Error("Value must be one of the items %".format(items.cs)).throw
+		}
+		^value
+
+	}
 }
 

--- a/ItemSpec.sc
+++ b/ItemSpec.sc
@@ -26,7 +26,7 @@ ItemSpec : ControlSpec {
 	unmap { arg value;
 		var index = items.indexOf(value);
 		if (index.isNil) { ^nil } {
-			index * (1.0 / items.size);
+			^index * (1.0 / items.size);
 		}
 	}
 

--- a/UpdateForwarder.sc
+++ b/UpdateForwarder.sc
@@ -107,7 +107,24 @@ UpdateForwarder {
 	}
 }
 
-UpdateFilter : UpdateForwarder {
+UpdateForwarderWithInit : UpdateForwarder {
+	var <lastObject;
+
+	onDependantAdded {
+				lastObject !? { |o| o.constrain };
+	}
+
+	update {
+		|object, what ...args|
+		lastObject = object;
+		super.update(object, what, *args);
+	}
+
+}
+
+
+
+UpdateFilter : UpdateForwarderWithInit {
 	var <>func;
 
 	*new {
@@ -123,7 +140,7 @@ UpdateFilter : UpdateForwarder {
 	}
 }
 
-UpdateTransform : UpdateForwarder {
+UpdateTransform : UpdateForwarderWithInit {
 	var <>func;
 
 	*new {


### PR DESCRIPTION
Changing *defaultSpec from `ItemsSpec` (which is probably a typo) to `ItemSpec`. (`ItemsSpec` is in Modality Toolkit but that's not a Connection dependency.)